### PR TITLE
Replace legacy validate_ functions with types

### DIFF
--- a/manifests/conf.pp
+++ b/manifests/conf.pp
@@ -87,10 +87,8 @@ define network::conf (
 
   $options_hash = undef,
 
-  $ensure       = present ) {
-
-  validate_re($ensure, ['present','absent'], 'Valid values are: present, absent. WARNING: If set to absent the conf file is removed.')
-
+  Enum['present', 'absent'] $ensure       = present
+) {
   include ::network
 
   $manage_path    = pick($path, "${::network::config_dir_path}/${name}")

--- a/manifests/mroute.pp
+++ b/manifests/mroute.pp
@@ -72,7 +72,7 @@
 # Deploys the file /etc/sysconfig/network/ifroute-$name.
 #
 define network::mroute (
-  $routes,
+  Hash $routes,
   $interface           = $name,
   $config_file_notify  = 'class_default',
   $restart_all_nic     = false,
@@ -82,9 +82,6 @@ define network::mroute (
   $route_down_template = undef,
   $table               = undef,
 ) {
-  # Validate our arrays
-  validate_hash($routes)
-
   include ::network
   $real_reload_command = $reload_command ? {
     undef => $::operatingsystem ? {

--- a/manifests/mroute/validate_gw.pp
+++ b/manifests/mroute/validate_gw.pp
@@ -2,5 +2,5 @@
 #
 define network::mroute::validate_gw($routes) {
   $route = $routes[$name]
-  validate_string($route)
+  assert_type(String, $route)
 }

--- a/manifests/route.pp
+++ b/manifests/route.pp
@@ -103,56 +103,24 @@
 # Copyright (C) 2011 Mike Arnold, unless otherwise noted.
 #
 define network::route (
-  $ipaddress,
-  $netmask,
-  $gateway   = undef,
-  $metric    = undef,
-  $mtu       = undef,
-  $scope     = undef,
-  $source    = undef,
-  $table     = undef,
+  Array $ipaddress,
+  Array $netmask,
+  Optional[Array] $gateway   = undef,
+  Optional[Array] $metric    = undef,
+  Optional[Array] $mtu       = undef,
+  Optional[Array] $scope     = undef,
+  Optional[Array] $source    = undef,
+  Optional[Array] $table     = undef,
   $cidr      = undef,
-  $family    = [ 'inet4' ],
+  Optional[Array] $family    = [ 'inet4' ],
   $interface = $name,
   $ensure    = 'present'
 ) {
-  # Validate our arrays
-  validate_array($ipaddress)
-  validate_array($netmask)
-
-  if $gateway {
-    validate_array($gateway)
-  }
-
-  if $metric {
-    validate_array($metric)
-  }
-
-  if $mtu {
-    validate_integer($mtu)
-  }
-
-  if $scope {
-    validate_array($scope)
-  }
-
-  if $source {
-    validate_array($source)
-  }
-
-  if $table {
-    validate_array($table)
-  }
-
   if $cidr {
-    validate_array($cidr)
+    assert_type(Array, $cidr)
     $_cidr = $cidr
   } else {
     $_cidr = build_cidr_array($netmask)
-  }
-
-  if $family {
-    validate_array($family)
   }
 
   include ::network

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -26,18 +26,11 @@
 #
 
 define network::rule (
-  $iprule,
+  Array $iprule,
   $interface = $name,
-  $family    = [],
+  Optional[Array] $family    = [],
   $ensure    = 'present'
 ) {
-  # Validate our arrays
-  validate_array($iprule)
-
-  if $family {
-    validate_array($family)
-  }
-
   include ::network
 
   case $::osfamily {


### PR DESCRIPTION
@gjenning pulling this code into my fork so I can continue to use the module. 

I'm only replacing the bare minimum to get this running with stdlib9 until hopefully puppet-network introduces support for multi-address configurations on Debian
https://github.com/voxpupuli/puppet-network/issues/99

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

